### PR TITLE
Try referencing other libraries

### DIFF
--- a/tests/someSpec.ts
+++ b/tests/someSpec.ts
@@ -1,3 +1,6 @@
+import * as Ajv from 'ajv';
+
 it('should work', () => {
+    console.log(Ajv.name);
     console.log('works');
 });


### PR DESCRIPTION
I've tried to use some other libs on the ``node_modues`` libraries. In this case *AJV* but in my app its already *Chai* that could not be found. I get the following error message:

> Error: Cannot find module './node_modules/ajv/lib/ajv.js'​​

Is this en ``entry-pattern`` thing that I need to configure?